### PR TITLE
解决ps -ef 无法获取完整pid，导致kill joy失败的问题

### DIFF
--- a/jd.sh
+++ b/jd.sh
@@ -274,13 +274,13 @@ joy(){
 
 kill_joy() {
 	echo -e "$green  执行kill_joy$start_script $white"
-	pid=$(ps -ef | grep "jd_crazy_joy_coin.js" | grep -v grep | awk '{print $1}')
+	pid=$(ps -ef ww | grep "jd_crazy_joy_coin.js" | grep -v grep | awk '{print $1}')
 	if [ $(echo $pid |wc -l ) == "1" ];then
 		echo -e "$yellow发现joy后台程序开始清理，请稍等$white"
-		for i in $pid
+		for joy_pid in `echo $pid`
 		do
-			echo "kill $i"
-			kill -9 $i
+			echo "kill $joy_pid"
+			kill -9 $joy_pid
 			sleep 2
 		done
 		echo -e "$green joy后台程序清理完成$white"


### PR DESCRIPTION
Signed-off-by: Zhenjian Zhang <itdesk.zhang@gmail.com>